### PR TITLE
FLASK_ENV will be removed in Flask v2.3

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,6 @@ DEBUG=False
 
 # Flask ENV
 FLASK_APP=run.py
-FLASK_ENV=production
 
 # If not provided, a random one is generated 
 # SECRET_KEY=<YOUR_SUPER_KEY_HERE>

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ $ pip3 install -r requirements.txt
 
 ```bash
 $ export FLASK_APP=run.py
-$ export FLASK_ENV=development
 ```
 
 <br />
@@ -123,11 +122,9 @@ $ pip3 install -r requirements.txt
 ```bash
 $ # CMD 
 $ set FLASK_APP=run.py
-$ set FLASK_ENV=development
 $
 $ # Powershell
 $ $env:FLASK_APP = ".\run.py"
-$ $env:FLASK_ENV = "development"
 ```
 
 <br />

--- a/env.sample
+++ b/env.sample
@@ -2,7 +2,6 @@
 DEBUG=True
 
 FLASK_APP=run.py
-FLASK_ENV=development
 
 # If not provided, a random one is generated 
 # SECRET_KEY=<YOUR_SUPER_KEY_HERE>


### PR DESCRIPTION
FLASK_ENV will be removed in Flask v2.3 in favor of `flask --debug run`. See below github issue and supporting documentation

https://github.com/pallets/flask/issues/4714

https://flask.palletsprojects.com/en/2.2.x/config/#ENV
